### PR TITLE
build: pin to a specific nightly Rust

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,9 +1,4 @@
 [toolchain]
-channel = "nightly"
-targets = [
-    "aarch64-apple-darwin",
-    "aarch64-unknown-linux-musl",
-    "wasm32-wasi",
-    "x86_64-apple-darwin",
-    "x86_64-unknown-linux-musl",
-]
+channel = "nightly-2022-11-04"
+targets = ["wasm32-wasi"]
+profile = "minimal"


### PR DESCRIPTION
Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

I've just chosen the same nightly pin as the Enarx repo uses, in order to eliminate the possibility of any differences and reduce the number of toolchains that need to be installed.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
