### PR TITLE
build: use `workspace.dependencies`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,23 +4,49 @@ version = "0.1.0"
 edition = "2021"
 
 [dev-dependencies]
-anyhow = "1.0.65"
-async-trait = "0.1.51"
-rustix = "0.35.11"
-serial_test = "0.9.0"
-tempfile = "3.3.0"
-tokio = { version = "1.21.2", features = [ "rt-multi-thread", "macros" ] }
-wash = { version = "0.1.0", git = "https://github.com/rvolosatovs/wash", artifact = "bin", target = "wasm32-wasi", default-features = false }
-wasi-common = "2.0.0"
-wasmtime = "2.0.0"
-wasmtime-vfs-memory = { path = "./memory" }
-wasmtime-vfs-ledger = { path = "./ledger" }
-wasmtime-vfs-file = { path = "./file" }
-wasmtime-vfs-dir = { path = "./dir" }
-wasmtime-wasi = "2.0.0"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+rustix = { workspace = true }
+serial_test = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = [ "rt-multi-thread", "macros" ] }
+wash = { workspace = true }
+wasi-common = { workspace = true }
+wasmtime = { workspace = true }
+wasmtime-vfs-memory = { workspace = true }
+wasmtime-vfs-ledger = { workspace = true }
+wasmtime-vfs-file = { workspace = true }
+wasmtime-vfs-dir = { workspace = true }
+wasmtime-wasi = { workspace = true }
 
 [features]
 interactive = []
 
 [workspace]
 members = ["ledger", "memory", "file", "dir", "keyfs"]
+
+[workspace.dependencies]
+anyhow = "1.0.65"
+async-trait = "0.1.51"
+digest = "0.10.5"
+ecdsa = "0.14.8"
+k256 = "0.11.1"
+p256 = "0.11.1"
+p384 = "0.11.1"
+rand = "0.8.5"
+rsa = "0.7.0-rc.1"
+rustix = "0.35.11"
+serial_test = "0.9.0"
+sha2 = "0.10.6"
+signature = "1.6.3"
+tempfile = "3.3.0"
+tokio = { version = "1.21.2", default-features = false }
+uuid = "1.1.2"
+wash = { version = "0.1.0", git = "https://github.com/rvolosatovs/wash", artifact = "bin", target = "wasm32-wasi", default-features = false }
+wasi-common = "2.0.0"
+wasmtime = "2.0.0"
+wasmtime-vfs-dir = { path = "./dir" }
+wasmtime-vfs-file = { path = "./file" }
+wasmtime-vfs-ledger = { path = "./ledger" }
+wasmtime-vfs-memory = { path = "./memory" }
+wasmtime-wasi = "2.0.0"

--- a/dir/Cargo.toml
+++ b/dir/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-wasmtime-vfs-ledger = { path = "../ledger" }
-wasmtime-vfs-memory = { path = "../memory" }
-wasmtime-vfs-file = { path = "../file" }
-async-trait = "0.1.51"
-wasi-common = "2.0.0"
+async-trait = { workspace = true }
+wasi-common = { workspace = true }
+wasmtime-vfs-file = { workspace = true }
+wasmtime-vfs-ledger = { workspace = true }
+wasmtime-vfs-memory = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1.21.2", default-features = false, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/file/Cargo.toml
+++ b/file/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-wasmtime-vfs-ledger = { path = "../ledger" }
-wasmtime-vfs-memory = { path = "../memory" }
-async-trait = "0.1.51"
-wasi-common = "2.0.0"
+async-trait = { workspace = true }
+wasi-common = { workspace = true }
+wasmtime-vfs-ledger = { workspace = true }
+wasmtime-vfs-memory = { workspace = true }

--- a/keyfs/Cargo.toml
+++ b/keyfs/Cargo.toml
@@ -4,24 +4,22 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-wasmtime-vfs-memory = { path = "../memory" }
-wasmtime-vfs-ledger = { path = "../ledger" }
-wasmtime-vfs-file = { path = "../file" }
-wasmtime-vfs-dir = { path = "../dir" }
-
-async-trait = "0.1.51"
-wasi-common = "2.0.0"
-
-k256 = { version = "0.11.1", features = ["ecdsa"] }
-p256 = { version = "0.11.1", features = ["ecdsa"] }
-p384 = { version = "0.11.1", features = ["ecdsa"] }
-uuid = { version = "1.1.2", features = ["v4"] }
-signature = { version = "1.6.3" }
-digest = { version = "0.10.5" }
-ecdsa = { version = "0.14.8" }
-sha2 = { version = "0.10.6" }
-rand = { version = "0.8.5" }
-rsa = { version = "0.7.0-rc.1" }
+async-trait = { workspace = true }
+digest = { workspace = true }
+ecdsa = { workspace = true }
+k256 = { workspace = true, features = ["ecdsa"] }
+p256 = { workspace = true, features = ["ecdsa"] }
+p384 = { workspace = true, features = ["ecdsa"] }
+rand = { workspace = true }
+rsa = { workspace = true }
+sha2 = { workspace = true }
+signature = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+wasi-common = { workspace = true }
+wasmtime-vfs-dir = { workspace = true }
+wasmtime-vfs-file = { workspace = true }
+wasmtime-vfs-ledger = { workspace = true }
+wasmtime-vfs-memory = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1.21.2", default-features = false, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.21.2", default-features = false, features = ["sync"] }
-wasmtime-vfs-ledger = { path = "../ledger" }
-async-trait = "0.1.51"
-wasi-common = "2.0.0"
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+wasi-common = { workspace = true }
+wasmtime-vfs-ledger = { workspace = true }


### PR DESCRIPTION
This significantly simplifies maintenance and helps us prevent ending up in a dependency hell downstream by ensuring that all versions (especially the wasmtime stuff) are consistent