### PR TITLE
fix(dir): return `Directory` filetype on stat

### DIFF
--- a/dir/src/lib.rs
+++ b/dir/src/lib.rs
@@ -424,7 +424,7 @@ impl WasiDir for OpenDir {
         Ok(Filestat {
             device_id: **self.link.inode.id.device(),
             inode: **self.link.inode.id,
-            filetype: FileType::RegularFile,
+            filetype: FileType::Directory,
             nlink: Arc::strong_count(&self.link.inode) as u64 * 2,
             size: 0, // FIXME
             atim: Some(ilock.access),


### PR DESCRIPTION
Looks like a typo, correct filetype is returned everywhere else for this kind of node, including `OpenDir` below https://github.com/enarx/vfs/blob/91b92631c51abad5f48fe304f6889886c4f9afe3/dir/src/lib.rs#L546