### PR TITLE
feat(directory): add `Directory::create_file`

### DIFF
--- a/dir/Cargo.toml
+++ b/dir/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 [dependencies]
 async-trait = { workspace = true }
 wasi-common = { workspace = true }
-wasmtime-vfs-file = { workspace = true }
 wasmtime-vfs-ledger = { workspace = true }
 wasmtime-vfs-memory = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
+wasmtime-vfs-file = { workspace = true }

--- a/file/src/lib.rs
+++ b/file/src/lib.rs
@@ -69,11 +69,12 @@ impl Node for File {
 }
 
 impl File {
-    pub fn new(parent: Arc<dyn Node>) -> Arc<Self> {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(parent: Arc<dyn Node>) -> Arc<dyn Node> {
         Self::with_data(parent, [])
     }
 
-    pub fn with_data(parent: Arc<dyn Node>, data: impl Into<Vec<u8>>) -> Arc<Self> {
+    pub fn with_data(parent: Arc<dyn Node>, data: impl Into<Vec<u8>>) -> Arc<dyn Node> {
         let id = parent.id().device().create_inode();
 
         let inode = Inode {

--- a/keyfs/src/generate.rs
+++ b/keyfs/src/generate.rs
@@ -297,7 +297,7 @@ impl Generate {
         let shared = public.encode(())?;
         let uuid = uuid::Uuid::new_v4();
 
-        let d = Directory::new(parent.clone());
+        let d = Directory::new(parent.clone(), None);
         d.attach("verify", Verify::new(d.clone(), public)).await?;
         d.attach("share", Share::new(d.clone(), shared)).await?;
         d.attach("sign", Sign::new(d.clone(), secret)).await?;

--- a/keyfs/src/lib.rs
+++ b/keyfs/src/lib.rs
@@ -25,7 +25,7 @@ pub const ES384: &[u8] = b"\x00\x00\x00\x08";
 pub const ES512: &[u8] = b"\x00\x00\x00\x09";
 
 pub async fn new(parent: Arc<dyn Node>) -> Result<Arc<dyn Node>, Error> {
-    let dir = Directory::device(parent);
+    let dir = Directory::device(parent, None);
     dir.attach("generate", Generate::new(dir.clone())).await?;
     dir.attach("trust", Trust::new(dir.clone())).await?;
     Ok(dir)
@@ -44,7 +44,7 @@ mod test {
     use super::*;
 
     async fn root(ledger: Arc<Ledger>) -> Result<Arc<dyn Node>, Error> {
-        let dir = Directory::root(ledger);
+        let dir = Directory::root(ledger, None);
         dir.attach("generate", Generate::new(dir.clone())).await?;
         dir.attach("trust", Trust::new(dir.clone())).await?;
         Ok(dir)

--- a/keyfs/src/trust.rs
+++ b/keyfs/src/trust.rs
@@ -203,7 +203,7 @@ impl Trust {
         let public = T::decode(&bytes[4..])?;
         let uuid = uuid::Uuid::new_v4();
 
-        let d = Directory::new(parent.clone());
+        let d = Directory::new(parent.clone(), None);
         d.attach("verify", Verify::new(d.clone(), public)).await?;
         d.attach("share", Share::new(d.clone(), bytes)).await?;
         parent.attach(&uuid.to_string(), d).await?;

--- a/tests/wash.rs
+++ b/tests/wash.rs
@@ -66,12 +66,12 @@ a.file b.dir
     ];
 
     // Construct the tmpfs tree.
-    let root = Directory::root(Ledger::new());
+    let root = Directory::root(Ledger::new(), Some(Arc::new(File::new)));
     for (path, data) in tree {
         let parent = root.get(path.rsplit_once('/').unwrap().0).await.unwrap();
         let child: Arc<dyn Node> = match data {
             Some(data) => File::with_data(parent, *data),
-            None => Directory::new(parent),
+            None => Directory::new(parent, Some(Arc::new(File::new))),
         };
 
         root.attach(path, child).await.unwrap();


### PR DESCRIPTION
This is required to allow for creation of directories, where files are
not "regular files", e.g. to implement networking

Unfortunately, it does not seem to be possible to use generics for this
due to downcasting used within the subcrate. This is an issue in
particular when a parent or child `Node` is downcasted to `Directory`

Blocking https://github.com/enarx/enarx/pull/2245