### PR TITLE
feat: add `path` `Node::open_file` parameter

### DIFF
--- a/file/src/lib.rs
+++ b/file/src/lib.rs
@@ -49,6 +49,7 @@ impl Node for File {
 
     async fn open_file(
         self: Arc<Self>,
+        _path: &str,
         dir: bool,
         read: bool,
         write: bool,

--- a/keyfs/src/generate.rs
+++ b/keyfs/src/generate.rs
@@ -235,6 +235,7 @@ impl Node for Generate {
 
     async fn open_file(
         self: Arc<Self>,
+        _path: &str,
         dir: bool,
         read: bool,
         write: bool,

--- a/keyfs/src/share.rs
+++ b/keyfs/src/share.rs
@@ -34,6 +34,7 @@ impl Node for Share {
 
     async fn open_file(
         self: Arc<Self>,
+        _path: &str,
         dir: bool,
         read: bool,
         write: bool,

--- a/keyfs/src/sign.rs
+++ b/keyfs/src/sign.rs
@@ -46,6 +46,7 @@ where
 
     async fn open_file(
         self: Arc<Self>,
+        _path: &str,
         dir: bool,
         read: bool,
         write: bool,

--- a/keyfs/src/trust.rs
+++ b/keyfs/src/trust.rs
@@ -145,6 +145,7 @@ impl Node for Trust {
 
     async fn open_file(
         self: Arc<Self>,
+        _path: &str,
         dir: bool,
         read: bool,
         write: bool,

--- a/keyfs/src/verify.rs
+++ b/keyfs/src/verify.rs
@@ -47,6 +47,7 @@ where
 
     async fn open_file(
         self: Arc<Self>,
+        _path: &str,
         dir: bool,
         read: bool,
         write: bool,

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -18,6 +18,7 @@ pub trait Node: 'static + Any + Send + Sync {
 
     async fn open_file(
         self: Arc<Self>,
+        path: &str,
         dir: bool,
         read: bool,
         write: bool,


### PR DESCRIPTION
Some special files on custom file systems (e.g. network) require the knowledge of the path at which they are opened, expose this as a parameter.

Signed-off-by: Roman Volosatovs <roman@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
