### PR TITLE
fix: update permissions for nix-update workflow

### DIFF
--- a/.github/workflows/nix-update.yml
+++ b/.github/workflows/nix-update.yml
@@ -7,4 +7,7 @@ on:
 
 jobs:
   nix-update:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: enarx/.github/.github/workflows/nix-update.yml@main


### PR DESCRIPTION
Signed-off-by: Dmitri Pal <dmitri@profian.com>

Added permissions to the nix-update.yml to invoke shared workflow with the correct context.